### PR TITLE
fix typo: Collocation -> Concordance

### DIFF
--- a/collocation.html
+++ b/collocation.html
@@ -151,7 +151,7 @@
             </li>
             <li><a class="subheader">Tools</a></li>
             <li><a class="waves-effect" href="segmentation.html">&nbsp;&nbsp;Segmentation</a></li>
-            <li><a class="waves-effect" href="concordance.html">&nbsp;&nbsp;Collocation</a></li>
+            <li><a class="waves-effect" href="concordance.html">&nbsp;&nbsp;Concordance</a></li>
             <li><a class="waves-effect" href="collocation.html">&nbsp;&nbsp;Collocation</a></li>
             <li><a class="waves-effect" href="sentipol.html">&nbsp;&nbsp;Sentipol</a></li>
             <li><a class="waves-effect" href="wordcloud.html">&nbsp;&nbsp;Wordcloud</a></li>


### PR DESCRIPTION
Duplicate *Collocation* appears when clicking on *Collocation* on the sidebar